### PR TITLE
fix render when no legend is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redsift/d3-rs-lines",
-  "version": "0.4.4",
+  "version": "0.4.5-legends-upd-2",
   "description": "Generates line charts using D3v4.",
   "keywords": [
     "line",

--- a/src/lines.js
+++ b/src/lines.js
@@ -530,7 +530,7 @@ export default function lines(id) {
       let _data = data.map(item => Object.assign(
             {},
             item,
-            {v: item.v.map((v, idx) => legendsEnabled.includes(idx) ? v : null)}
+            {v: item.v.map((v, idx) => !legend.length || legendsEnabled.includes(idx) ? v : null)}
           )
       );
       if (_data.length > 0) {
@@ -1031,9 +1031,9 @@ export default function lines(id) {
 
         let x = scaleI(item[0]);
 
-        let nested = item[1].data;
+        let nested = item[1] !== null ? item[1].data : null;
 
-        if (nested !== undefined) {
+        if (nested !== undefined && nested !== null) {
           item = nested;
         }
 


### PR DESCRIPTION
fix issue https://github.com/redsift/d3-rs-lines/issues/13.

If no `legend` is provided, then don't discriminate the datasets by `enabledLegends`.